### PR TITLE
fix: trace log cause panic

### DIFF
--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -138,7 +138,7 @@ func ExportAccountsBalanceWithProof(app *app.BNBBeaconChain, outputPath string) 
 		if proofLength := len(proof.Siblings); proofLength > maxProofLength {
 			maxProofLength = proofLength
 		}
-		trace("address:", accounts[i].Address.String(), "proof:", nProof, "leaf:", leaf.Print())
+		trace("address:", leaf.Address.String(), "proof:", nProof, "leaf:", leaf.Print())
 	}
 	trace("max proof length:", maxProofLength)
 


### PR DESCRIPTION
## Description
fix: trace log causes panic

## Rationale

The length of the proof will not be equal to the length of the account (1 account may have multiple tokens)